### PR TITLE
Fix: Final deployment setup with corrected asset paths

### DIFF
--- a/App.tsx
+++ b/App.tsx
@@ -86,7 +86,7 @@ const App: React.FC = () => {
     const loadInitialData = async () => {
       let manifestMap = new Map<string, string>();
       try {
-        const response = await fetch('/data/manifest.json');
+        const response = await fetch(`${import.meta.env.BASE_URL}data/manifest.json`);
         if (!response.ok) throw new Error('Failed to fetch manifest');
         const manifest = await response.json();
         
@@ -125,7 +125,7 @@ const App: React.FC = () => {
     if (manifestVersions.has(date)) {
         try {
             const path = manifestVersions.get(date)!;
-            const response = await fetch(path);
+            const response = await fetch(`${import.meta.env.BASE_URL}${path}`);
             if (!response.ok) throw new Error(`Failed to fetch ${path}`);
             const gardenState: GardenState = await response.json();
             

--- a/i18n/LanguageContext.tsx
+++ b/i18n/LanguageContext.tsx
@@ -22,8 +22,8 @@ export const LanguageProvider = ({ children }: { children: ReactNode }) => {
     if (!translations) {
       const fetchTranslations = async () => {
         try {
-          const esPromise = fetch('/i18n/locales/es.json').then(res => res.json());
-          const glPromise = fetch('/i18n/locales/gl.json').then(res => res.json());
+          const esPromise = fetch(`${import.meta.env.BASE_URL}i18n/locales/es.json`).then(res => res.json());
+          const glPromise = fetch(`${import.meta.env.BASE_URL}i18n/locales/gl.json`).then(res => res.json());
 
           const [es, gl] = await Promise.all([esPromise, glPromise]);
           

--- a/index.html
+++ b/index.html
@@ -2,7 +2,6 @@
 <html lang="en">
   <head>
     <meta charset="UTF-8" />
-    <link rel="icon" type="image/svg+xml" href="/vite.svg" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Interactive Garden Map</title>
   <script type="importmap">

--- a/public/data/manifest.json
+++ b/public/data/manifest.json
@@ -2,15 +2,15 @@
   "versions": [
    {
       "date": "2025-08-20",
-      "path": "/data/2025-08-20.json"
+      "path": "data/2025-08-20.json"
     }, 
     {
       "date": "2025-08-01",
-      "path": "/data/2025-08-01.json"
+      "path": "data/2025-08-01.json"
     },
     {
       "date": "2024-05-25",
-      "path": "/data/2024-05-25.json"
+      "path": "data/2024-05-25.json"
     }
     
   ]


### PR DESCRIPTION
This commit provides the definitive fix for deploying the application to GitHub Pages. It addresses all known issues, including 404 errors for static assets, incorrect build configurations, and broken asset paths in the deployed application.

Key changes:
- Corrects all dynamic `fetch()` calls in the application (`App.tsx`, `LanguageContext.tsx`) to prepend `import.meta.env.BASE_URL`. This ensures that data files and translations are fetched from the correct path on GitHub Pages.
- Makes paths in `data/manifest.json` relative so they can be correctly resolved with the base URL.
- Removes a `<link>` tag in `index.html` that pointed to a non-existent `vite.svg` file, resolving the final 404 error.
- All previous fixes are included: GitHub Actions workflow, `public` directory setup, and a proper local Tailwind CSS build configuration.