### PR TITLE
fix: Configure git user in deployment workflow

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -25,6 +25,8 @@ jobs:
 
       - name: Deploy
         run: |
+          git config --global user.name 'github-actions[bot]'
+          git config --global user.email 'github-actions[bot]@users.noreply.github.com'
           git remote set-url origin https://git:${GITHUB_TOKEN}@github.com/${GITHUB_REPOSITORY}.git
           npm run deploy
         env:


### PR DESCRIPTION
This commit fixes the GitHub Actions workflow by adding a step to configure the git user name and email before running the deploy script. This is necessary to prevent the 'Author identity unknown' error when `gh-pages` tries to create a commit.